### PR TITLE
Added functionaly to update markers along with ohlc data without manual page reload

### DIFF
--- a/pytvlwcharts/tvlwcharts.py
+++ b/pytvlwcharts/tvlwcharts.py
@@ -122,7 +122,15 @@ _TEMPLATE = jinja2.Template("""
                   })
                   .then(response => {
                       {% for series in chart.series %}
-                      this.chart_series_{{ series.series_name }}.update(response.data.{{ series.series_name }}[0])
+                      if ("{{ series.series_name }}"=="ohlc"){
+                            this.chart_series_{{ series.series_name }}.update(response.data.{{ series.series_name }}[0])
+                            if (response.data.markers.length){
+                              this.chart_series_ohlc.setMarkers(this.chart_series_ohlc.markers().concat(response.data.{{ series.series_name }}[0]))
+                            }
+                            }
+                      else{
+                          this.chart_series_{{ series.series_name }}.update(response.data.{{ series.series_name }}[0])
+                      }
                       {% endfor %}
                   })
           } catch (error) {
@@ -224,7 +232,15 @@ _TEMPLATES = jinja2.Template("""
                   })
                   .then(response => {
                       {% for series in chart.series %}
-                      this.chart_series_{{ series.series_name }}.update(response.data.{{ series.series_name }}[0])
+                      if ("{{ series.series_name }}"=="ohlc"){
+                            this.chart_series_{{ series.series_name }}.update(response.data.{{ series.series_name }}[0])
+                            if (response.data.markers.length){
+                              this.chart_series_ohlc.setMarkers(this.chart_series_ohlc.markers().concat(response.data.{{ series.series_name }}[0]))
+                            }
+                            }
+                      else{
+                          this.chart_series_{{ series.series_name }}.update(response.data.{{ series.series_name }}[0])
+                      }
                       {% endfor %}
                   })
           } catch (error) {


### PR DESCRIPTION
As mentioned in #9, how to add markers at the time of preparing the chart, but I was unable to update marker data after referring \data endpoint which is mentoined  in https://colab.research.google.com/drive/1w1T2erRjyz3xLkentuIffI75z9kUkN6_?usp=sharing.

I have updated the update function in pytvlwcharts.py and now by passing markers like:
data={
                "ohlc": ndf[["time", "open", "high", "low", "close", "position", "color", "shape", "text"]].tail(1)
                .replace('', np.nan).dropna(axis=1,how='any')
                .to_dict(orient="records"),
                "markers": ndf[["time", "position", "color", "shape", "text"]].replace('', np.nan).dropna().tail(1)
                .to_dict(orient="records")[:1],
                "volume": ndf[["time", "volume", "volColor"]].tail(1)
                .rename(columns={"volume": "value", "volColor": "color"})
                .to_dict(orient="records")
              }
Chart can easily update markers.
